### PR TITLE
Rename group change handler

### DIFF
--- a/tgbot/handlers/user.py
+++ b/tgbot/handlers/user.py
@@ -72,7 +72,7 @@ async def add_group_id(message: Message, group_id: str, state: FSMContext, sessi
 
 
 @user_router.message(F.text.as_("group_id"), UserForm.Change)
-async def add_group_id(message: Message, group_id: str, state: FSMContext, session: AsyncSession):
+async def change_group_id(message: Message, group_id: str, state: FSMContext, session: AsyncSession):
     """
     Обрабатывает ввод ID группы пользователем и сохраняет его в базе данных.
 


### PR DESCRIPTION
## Summary
- rename handler for the `UserForm.Change` state to `change_group_id`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6884a44be0a483269b34e74ee2993d44