### PR TITLE
Use logging for reminder output

### DIFF
--- a/tgbot/misc/work_with_group.py
+++ b/tgbot/misc/work_with_group.py
@@ -1,4 +1,5 @@
 from typing import Sequence
+import logging
 
 from aiogram import Bot
 from aiogram.enums import ParseMode
@@ -40,7 +41,7 @@ async def send_reminders(bot: Bot, ready_remind_list: Sequence[Row[tuple[Remind,
         None
     """
 
-    print(f"Reminders is {type(ready_remind_list)}")
+    logging.info(f"Reminders is {type(ready_remind_list)}")
 
     for remind, user in ready_remind_list:
 


### PR DESCRIPTION
## Summary
- switch `print` to `logging.info` in `send_reminders`
- import logging in `work_with_group.py`

## Testing
- `python -m py_compile tgbot/misc/work_with_group.py`


------
https://chatgpt.com/codex/tasks/task_e_6884a44ad658832698b831d28ce9da80