### PR TITLE
Remove unused ScalarResult import

### DIFF
--- a/tgbot/misc/work_with_group.py
+++ b/tgbot/misc/work_with_group.py
@@ -4,7 +4,7 @@ import logging
 from aiogram import Bot
 from aiogram.enums import ParseMode
 from aiogram.utils.text_decorations import markdown_decoration
-from sqlalchemy import ScalarResult, Row
+from sqlalchemy import Row
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlite import Remind, User


### PR DESCRIPTION
## Summary
- clean up import of `ScalarResult` in `work_with_group.py`

## Testing
- `flake8 tgbot/misc/work_with_group.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884aaa6979c8326845186f29e930de3