### PR TITLE
Add basic tests and CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,22 @@
+name: Run tests
+
+on:
+  push:
+    paths-ignore:
+      - '**/README.md'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest pytest-asyncio
+      - name: Run tests
+        run: pytest -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlite.models import Base
+
+@pytest_asyncio.fixture
+async def session(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/test.db", future=True)
+    async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with async_session() as s:
+        yield s
+    await engine.dispose()

--- a/tests/test_sqlite_requests.py
+++ b/tests/test_sqlite_requests.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+import sqlite.requests as rq
+
+@pytest.mark.asyncio
+async def test_user_operations(session):
+    user_id = 123
+    assert await rq.check_user(user_id, session) is False
+    await rq.add_user(user_id=user_id, group_id=1, session=session)
+    assert await rq.check_user(user_id, session) is True
+    group_id = await rq.get_group_id(user_id, session)
+    assert group_id == 1
+
+@pytest.mark.asyncio
+async def test_remind_crud(session):
+    user_id = 321
+    await rq.add_user(user_id=user_id, group_id=10, session=session)
+    now = datetime.now()
+    await rq.set_remind(tg_id=user_id, data=now, text="test", hours=1, session=session)
+    reminders = list(await rq.get_reminders(session, user_id))
+    assert len(reminders) == 1
+    remind = reminders[0]
+    got = await rq.get_one_remind(remind.id, session)
+    assert got.text == "test"
+    await rq.delete_remind(remind.id, session)
+    reminders_after = list(await rq.get_reminders(session, user_id))
+    assert reminders_after == []
+
+@pytest.mark.asyncio
+async def test_check_remind_sql_calls_send(monkeypatch, session):
+    calls = {}
+    async def fake_send_reminders(bot, ready, sess):
+        calls['called'] = True
+    monkeypatch.setattr(rq, 'send_reminders', fake_send_reminders)
+    await rq.add_user(user_id=1, group_id=1, session=session)
+    past = datetime.now() - timedelta(hours=1)
+    await rq.set_remind(tg_id=1, data=past, text="r", hours=1, session=session)
+    class DummyBot:
+        pass
+    await rq.check_remind_sql(DummyBot(), session)
+    assert calls.get('called') is True

--- a/tests/test_user_handlers.py
+++ b/tests/test_user_handlers.py
@@ -1,0 +1,50 @@
+import pytest
+from types import SimpleNamespace
+
+from tgbot.handlers import user as user_handlers
+from tgbot.misc.states import UserForm
+
+class FakeMessage:
+    def __init__(self, user_id):
+        self.from_user = SimpleNamespace(id=user_id)
+        self.answers = []
+
+    async def answer(self, text, **kwargs):
+        self.answers.append(text)
+
+class FakeState:
+    def __init__(self):
+        self.state = None
+
+    async def set_state(self, s):
+        self.state = s
+
+    async def clear(self):
+        self.state = None
+
+@pytest.mark.asyncio
+async def test_user_start_new_user():
+    msg = FakeMessage(1)
+    await user_handlers.user_start(msg, new_user=True)
+    assert any("Отправьте сюда id группы" in a for a in msg.answers)
+
+@pytest.mark.asyncio
+async def test_add_group_id_valid(monkeypatch, session):
+    calls = {}
+    async def fake_add_user(user_id, group_id, session):
+        calls['data'] = (user_id, group_id)
+    monkeypatch.setattr(user_handlers, 'add_user', fake_add_user)
+    state = FakeState()
+    msg = FakeMessage(5)
+    await user_handlers.add_group_id(msg, '10', state, session)
+    assert calls['data'] == (5, 10)
+    assert state.state is None
+    assert any("сохранен" in a for a in msg.answers)
+
+@pytest.mark.asyncio
+async def test_add_group_id_invalid(monkeypatch, session):
+    monkeypatch.setattr(user_handlers, 'add_user', lambda *a, **k: None)
+    state = FakeState()
+    msg = FakeMessage(5)
+    await user_handlers.add_group_id(msg, 'bad', state, session)
+    assert any("Неверный ввод" in a for a in msg.answers)


### PR DESCRIPTION
## Summary
- add pytest workflow
- add pytest fixtures
- test sqlite requests helpers
- test selected user handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a457118083268fcc7852b1f610b6