### PR TITLE
Fix unused exception variable

### DIFF
--- a/tgbot/services/broadcaster.py
+++ b/tgbot/services/broadcaster.py
@@ -31,7 +31,7 @@ async def send_message(
             disable_notification=disable_notification,
             reply_markup=reply_markup,
         )
-    except exceptions.TelegramBadRequest as e:
+    except exceptions.TelegramBadRequest:
         logging.error("Telegram server says - Bad Request: chat not found")
     except exceptions.TelegramForbiddenError:
         logging.error(f"Target [ID:{user_id}]: got TelegramForbiddenError")


### PR DESCRIPTION
## Summary
- remove unused variable from TelegramBadRequest handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884aaa7a2c08326b3ddea8b5d73b9ce