### PR TITLE
Fix unused imports in sqlite package

### DIFF
--- a/sqlite/__init__.py
+++ b/sqlite/__init__.py
@@ -1,3 +1,11 @@
 from .models import Remind, User, make_base
 from .base import TableNameMixin, TimestampMixin
 
+__all__ = [
+    "Remind",
+    "User",
+    "make_base",
+    "TableNameMixin",
+    "TimestampMixin",
+]
+


### PR DESCRIPTION
## Summary
- re-export models and mixins in `sqlite.__init__` to silence ruff F401

## Testing
- `ruff check sqlite/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6884aaa8271483268f994166783efbe9